### PR TITLE
Fix trailing slash of the API `resource_uri`

### DIFF
--- a/api_client/python/timesketch_api_client/client_test.py
+++ b/api_client/python/timesketch_api_client/client_test.py
@@ -15,6 +15,7 @@
 from __future__ import unicode_literals
 
 import unittest
+
 import mock
 
 from . import client
@@ -35,7 +36,12 @@ class TimesketchApiTest(unittest.TestCase):
         response = self.api_client.fetch_resource_data("sketches/")
         self.assertIsInstance(response, dict)
 
-    # TODO: Add test for create_sketch()
+    def test_create_sketch(self):
+        """Test to create a sketch."""
+        sketch = self.api_client.create_sketch("test", "test")
+        self.assertEqual(sketch.id, 1)
+        self.assertEqual(sketch.name, "test")
+        self.assertEqual(sketch.description, "test")
 
     def test_get_sketch(self):
         """Test to get a sketch."""

--- a/api_client/python/timesketch_api_client/sketch.py
+++ b/api_client/python/timesketch_api_client/sketch.py
@@ -54,7 +54,7 @@ class Sketch(resource.BaseResource):
         self.api = api
         self._archived = None
         self._sketch_name = sketch_name
-        super().__init__(api=api, resource_uri=f"sketches/{self.id}")
+        super().__init__(api=api, resource_uri=f"sketches/{self.id}/")
 
     @property
     def acl(self):

--- a/api_client/python/timesketch_api_client/test_lib.py
+++ b/api_client/python/timesketch_api_client/test_lib.py
@@ -644,7 +644,7 @@ def mock_response(*args, **kwargs):
     url_router = {
         "http://127.0.0.1": MockResponse(text_data=auth_text_data),
         "http://127.0.0.1/api/v1/sketches/": MockResponse(json_data=sketch_list_data),
-        "http://127.0.0.1/api/v1/sketches/1": MockResponse(json_data=sketch_data),
+        "http://127.0.0.1/api/v1/sketches/1/": MockResponse(json_data=sketch_data),
         "http://127.0.0.1/api/v1/sketches/1/event/?searchindex_id=test_index&event_id=test_event": MockResponse(  # pylint: disable=line-too-long
             json_data=event_data_1
         ),


### PR DESCRIPTION
Fix trailing slash in sketch API resource URI
The sketch API functions do not work when the `resource_uri` does not end with a trailing slash: 

`requests.exceptions.ConnectionError:HTTPConnectionPool
(host='%5c127.0.0.1', port=80): Max retries exceeded with url:
/api/v1/sketches/1/ (Caused by
NameResolutionError("<urllib3.connection.HTTPConnection object at
0x7e5a177ba810>: Failed to resolve '%5c127.0.0.1' ([Errno -2] Name or service
not known)"))`